### PR TITLE
compare timestamp separately from other attributes

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -62,7 +62,7 @@ class Util
             if ($onMaster === true && $onSlave === true) {
 
                 // Path files are different somehow.
-                if (static::isDiff($master, $slave) === true) {
+                if (static::isDiff($master, $slave) === true || static::isNewer($master, $slave) === true) {
                     $this->updates[$path] = $master;
                 }
             }
@@ -88,10 +88,22 @@ class Util
      */
     public static function isDiff($path1, $path2)
     {
+        unset($path1["timestamp"]);
+        unset($path2["timestamp"]);
         $diffKeys   = array_diff_key($path1, $path2);
         $diffValues = array_diff($path1, $path2);
 
         return count($diffKeys) > 0 || count($diffValues) > 0;
+    }
+
+    /**
+     * @param $master
+     * @param $slave
+     * @return bool
+     */
+    public static function isNewer($master, $slave)
+    {
+        return $master["timestamp"] > $slave["timestamp"];
     }
 
     /**


### PR DESCRIPTION
This is my first public pull request so I apoligize in advance if I did anything wrong.  When running a simple test, the slave always updated even if the master was unchanged.  This is because the rule for updating was "if any field between the two files is different".  In my use case, the timestamps never match because the slave it is always updated after the master is written.  Therefore, the slave was updated every single time.  This is not an issue on a local drive but if you were syncing to dropbox or AWS it would actually create an automatic backup every time you do this, and your could drive would grow every day, consuming resources.  So I removed the timestamp field from the isDiff rule, and added an isNewer function.  It will now update if either is true.  In my mind, the only thing that matters is isNewer, but since you must have had good reason to compare all attirubtes I included both. If there is no reason, I would actually recommend to remove isDiff altogether and only run isNewer, it would be faster too.    
Fixes #9 