### PR TITLE
Folder branch

### DIFF
--- a/src/Sync.php
+++ b/src/Sync.php
@@ -95,8 +95,7 @@ class Sync
      */
     public function syncWrites()
     {
-        foreach ($this->util->getWrites() as $path) {
-            echo "writing " . $path["path"] . PHP_EOL;
+        foreach ($this->util->getWrites() as $path) {            
             $this->put($path);
         }
 
@@ -118,11 +117,9 @@ class Sync
             }
             // A dir? They're deleted a special way.
             elseif ($path['dir'] === true) {
-                echo "deleting " . $path["path"] . PHP_EOL;
                 $this->slave->deleteDir($path['path']);
             }
             else {
-                echo "deleting " . $path["path"] . PHP_EOL;
                 $this->slave->delete($path['path']);
             }
         }
@@ -138,7 +135,6 @@ class Sync
     public function syncUpdates()
     {
         foreach ($this->util->getUpdates() as $path) {
-            echo "updating " . $path["path"] . PHP_EOL;
             $this->put($path);
         }
 

--- a/src/Sync.php
+++ b/src/Sync.php
@@ -54,9 +54,20 @@ class Sync
      *
      * @return Util
      */
-    public function getUtil()
+    public function getUtil($path=null)
     {
         return $this->util;
+    }
+
+    public function setFolder($path='/')
+    {
+      $this->util = new Util($this->master, $this->slave, $path);
+      return $this;
+    }
+
+    public function exclude($path=null)
+    {
+      if($path) $this->excludes[] = $path;
     }
 
     /**
@@ -85,6 +96,7 @@ class Sync
     public function syncWrites()
     {
         foreach ($this->util->getWrites() as $path) {
+            echo "writing " . $path["path"] . PHP_EOL;
             $this->put($path);
         }
 
@@ -106,9 +118,11 @@ class Sync
             }
             // A dir? They're deleted a special way.
             elseif ($path['dir'] === true) {
+                echo "deleting " . $path["path"] . PHP_EOL;
                 $this->slave->deleteDir($path['path']);
             }
             else {
+                echo "deleting " . $path["path"] . PHP_EOL;
                 $this->slave->delete($path['path']);
             }
         }
@@ -124,6 +138,7 @@ class Sync
     public function syncUpdates()
     {
         foreach ($this->util->getUpdates() as $path) {
+            echo "updating " . $path["path"] . PHP_EOL;
             $this->put($path);
         }
 
@@ -135,8 +150,11 @@ class Sync
      *
      * @return $this
      */
-    public function sync()
+    public function sync($folder = null)
     {
+        if($folder) {
+          $this->setFolder($folder);
+        }
         return $this
             ->syncWrites()
             ->syncUpdates()

--- a/src/Util.php
+++ b/src/Util.php
@@ -62,7 +62,7 @@ class Util
             if ($onMaster === true && $onSlave === true) {
 
                 // Path files are different somehow.
-                if (static::isDiff($master, $slave) === true) {
+                if (static::isDiff($master, $slave) === true || static::isNewer($master, $slave) === true) {
                     $this->updates[$path] = $master;
                 }
             }
@@ -88,10 +88,22 @@ class Util
      */
     public static function isDiff($path1, $path2)
     {
+        unset($path1["timestamp"]);
+        unset($path2["timestamp"]);
         $diffKeys   = array_diff_key($path1, $path2);
         $diffValues = array_diff($path1, $path2);
 
         return count($diffKeys) > 0 || count($diffValues) > 0;
+    }
+
+    /**
+     * @param $master
+     * @param $slave
+     * @return bool
+     */
+    public static function isNewer($master, $slave)
+    {
+        return $master["timestamp"] > $slave["timestamp"];
     }
 
     /**


### PR DESCRIPTION
Allows use of a folder like this : 
```
$sync = ServiceLocator::get('sync');
      $sync->sync('/subfolderA');
      $sync->sync('/subfolderB');
      $sync->sync('/subfolderC');
```
Behind the scenes it uses a ->setFolder('subfolder') function that returns $this so it is chainable with ->getUtil()

I would like to set a blacklist somehow, but this gets me 95% of the way there.  The blacklist would be to avoid backing up logs.  