### PR TITLE
Allow using more recent versions of flysystem

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
 
     "require": {
-        "league/flysystem": "1.0.*"
+        "league/flysystem": "^1.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
Allow installing https://github.com/thephpleague/flysystem/releases/tag/1.1.3 that is backward compatible with 1.0.x 